### PR TITLE
Fix missing `omitempty` JSON tags and add support for groups

### DIFF
--- a/group.go
+++ b/group.go
@@ -7,50 +7,50 @@ import (
 )
 
 type CreateGroup struct {
-	Color         string      `json:"color"`
-	ColorKey      string      `json:"color_key"`
-	Description   string      `json:"description"`
-	DisplayIconID string      `json:"display_icon_id"`
-	MemberIds     []string    `json:"member_ids"`
-	MentionName   interface{} `json:"mention_name"`
-	Name          interface{} `json:"name"`
-	WorkflowIds   []int       `json:"workflow_ids"`
+	Color         string      `json:"color,omitempty"`
+	ColorKey      string      `json:"color_key,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	DisplayIconID string      `json:"display_icon_id,omitempty"`
+	MemberIds     []string    `json:"member_ids,omitempty"`
+	MentionName   interface{} `json:"mention_name,omitempty"`
+	Name          interface{} `json:"name,omitempty"`
+	WorkflowIds   []int       `json:"workflow_ids,omitempty"`
 }
 
 type UpdateGroup struct {
-	Archived      bool        `json:"archived"`
-	Color         string      `json:"color"`
-	ColorKey      string      `json:"color_key"`
-	Description   string      `json:"description"`
-	DisplayIconID string      `json:"display_icon_id"`
-	MemberIds     []string    `json:"member_ids"`
-	MentionName   interface{} `json:"mention_name"`
-	Name          interface{} `json:"name"`
-	WorkflowIds   []int       `json:"workflow_ids"`
+	Archived      bool        `json:"archived,omitempty"`
+	Color         string      `json:"color,omitempty"`
+	ColorKey      string      `json:"color_key,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	DisplayIconID string      `json:"display_icon_id,omitempty"`
+	MemberIds     []string    `json:"member_ids,omitempty"`
+	MentionName   interface{} `json:"mention_name,omitempty"`
+	Name          interface{} `json:"name,omitempty"`
+	WorkflowIds   []int       `json:"workflow_ids,omitempty"`
 }
 
 type Group struct {
-	AppURL      string `json:"app_url,omitempty"`
-	Archived    bool   `json:"archived,omitempty"`
-	Color       string `json:"color,omitempty"`
-	ColorKey    string `json:"color_key,omitempty"`
-	Description string `json:"description,omitempty"`
+	AppURL      string `json:"app_url,omitempty,omitempty"`
+	Archived    bool   `json:"archived,omitempty,omitempty"`
+	Color       string `json:"color,omitempty,omitempty"`
+	ColorKey    string `json:"color_key,omitempty,omitempty"`
+	Description string `json:"description,omitempty,omitempty"`
 	DisplayIcon struct {
-		CreatedAt  time.Time `json:"created_at,omitempty"`
-		EntityType string    `json:"entity_type,omitempty"`
-		ID         string    `json:"id,omitempty"`
-		UpdatedAt  time.Time `json:"updated_at,omitempty"`
-		URL        string    `json:"url,omitempty"`
-	} `json:"display_icon,omitempty"`
-	EntityType        string   `json:"entity_type,omitempty"`
-	ID                string   `json:"id,omitempty"`
-	MemberIds         []string `json:"member_ids,omitempty"`
-	MentionName       string   `json:"mention_name,omitempty"`
-	Name              string   `json:"name,omitempty"`
-	NumEpicsStarted   int      `json:"num_epics_started,omitempty"`
-	NumStories        int      `json:"num_stories,omitempty"`
-	NumStoriesStarted int      `json:"num_stories_started,omitempty"`
-	WorkflowIds       []int    `json:"workflow_ids,omitempty"`
+		CreatedAt  time.Time `json:"created_at,omitempty,omitempty"`
+		EntityType string    `json:"entity_type,omitempty,omitempty"`
+		ID         string    `json:"id,omitempty,omitempty"`
+		UpdatedAt  time.Time `json:"updated_at,omitempty,omitempty"`
+		URL        string    `json:"url,omitempty,omitempty"`
+	} `json:"display_icon,omitempty,omitempty"`
+	EntityType        string   `json:"entity_type,omitempty,omitempty"`
+	ID                string   `json:"id,omitempty,omitempty"`
+	MemberIds         []string `json:"member_ids,omitempty,omitempty"`
+	MentionName       string   `json:"mention_name,omitempty,omitempty"`
+	Name              string   `json:"name,omitempty,omitempty"`
+	NumEpicsStarted   int      `json:"num_epics_started,omitempty,omitempty"`
+	NumStories        int      `json:"num_stories,omitempty,omitempty"`
+	NumStoriesStarted int      `json:"num_stories_started,omitempty,omitempty"`
+	WorkflowIds       []int    `json:"workflow_ids,omitempty,omitempty"`
 }
 
 func (ch *Shortcut) ListGroups() ([]Group, error) {

--- a/group.go
+++ b/group.go
@@ -1,0 +1,101 @@
+package shortcut
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type CreateGroup struct {
+	Color         string      `json:"color"`
+	ColorKey      string      `json:"color_key"`
+	Description   string      `json:"description"`
+	DisplayIconID string      `json:"display_icon_id"`
+	MemberIds     []string    `json:"member_ids"`
+	MentionName   interface{} `json:"mention_name"`
+	Name          interface{} `json:"name"`
+	WorkflowIds   []int       `json:"workflow_ids"`
+}
+
+type UpdateGroup struct {
+	Archived      bool        `json:"archived"`
+	Color         string      `json:"color"`
+	ColorKey      string      `json:"color_key"`
+	Description   string      `json:"description"`
+	DisplayIconID string      `json:"display_icon_id"`
+	MemberIds     []string    `json:"member_ids"`
+	MentionName   interface{} `json:"mention_name"`
+	Name          interface{} `json:"name"`
+	WorkflowIds   []int       `json:"workflow_ids"`
+}
+
+type Group struct {
+	AppURL      string `json:"app_url,omitempty"`
+	Archived    bool   `json:"archived,omitempty"`
+	Color       string `json:"color,omitempty"`
+	ColorKey    string `json:"color_key,omitempty"`
+	Description string `json:"description,omitempty"`
+	DisplayIcon struct {
+		CreatedAt  time.Time `json:"created_at,omitempty"`
+		EntityType string    `json:"entity_type,omitempty"`
+		ID         string    `json:"id,omitempty"`
+		UpdatedAt  time.Time `json:"updated_at,omitempty"`
+		URL        string    `json:"url,omitempty"`
+	} `json:"display_icon,omitempty"`
+	EntityType        string   `json:"entity_type,omitempty"`
+	ID                string   `json:"id,omitempty"`
+	MemberIds         []string `json:"member_ids,omitempty"`
+	MentionName       string   `json:"mention_name,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	NumEpicsStarted   int      `json:"num_epics_started,omitempty"`
+	NumStories        int      `json:"num_stories,omitempty"`
+	NumStoriesStarted int      `json:"num_stories_started,omitempty"`
+	WorkflowIds       []int    `json:"workflow_ids,omitempty"`
+}
+
+func (ch *Shortcut) ListGroups() ([]Group, error) {
+	body, err := ch.listResources("groups")
+	if err != nil {
+		return []Group{}, err
+	}
+	groups := []Group{}
+	json.Unmarshal(body, &groups)
+	return groups, nil
+}
+
+func (ch *Shortcut) CreateGroup(newGroup CreateGroup) (Group, error) {
+	jsonStr, _ := json.Marshal(newGroup)
+
+	body, err := ch.createObject("groups", jsonStr)
+	if err != nil {
+		return Group{}, err
+	}
+	group := Group{}
+	json.Unmarshal(body, &group)
+	return group, nil
+}
+
+func (ch *Shortcut) GetGroup(projectID int64) (Group, error) {
+	body, err := ch.getResource(fmt.Sprintf("%s/%d", "groups", projectID))
+	if err != nil {
+		return Group{}, err
+	}
+	group := Group{}
+	json.Unmarshal(body, &group)
+	return group, nil
+}
+
+func (ch *Shortcut) UpdateGroup(updatedGroup UpdateGroup, projectID int64) (Group, error) {
+	jsonStr, _ := json.Marshal(updatedGroup)
+	body, err := ch.updateResource(fmt.Sprintf("%s/%d", "groups", projectID), jsonStr)
+	if err != nil {
+		return Group{}, err
+	}
+	group := Group{}
+	json.Unmarshal(body, &group)
+	return group, nil
+}
+
+func (ch *Shortcut) DeleteGroup(projectID int64) error {
+	return ch.deleteResource(fmt.Sprintf("%s/%d", "groups", projectID))
+}

--- a/story.go
+++ b/story.go
@@ -16,6 +16,7 @@ type CreateStory struct {
 	ExternalID      string            `json:"external_id"`
 	FileIds         []int64           `json:"file_ids"`
 	FollowerIds     []string          `json:"follower_ids"`
+	GroupID         string            `json:"group_id"`
 	Labels          []CreateLabel     `json:"labels"`
 	LinkedFileIds   []int64           `json:"linked_file_ids"`
 	Name            string            `json:"name"`
@@ -37,6 +38,7 @@ type Story struct {
 	Description     string      `json:"description"`
 	EpicID          int64       `json:"epic_id"`
 	Estimate        int64       `json:"estimate"`
+	ExternalID      string      `json:"external_id"`
 	FileIds         []int64     `json:"file_ids"`
 	FollowerIds     []string    `json:"follower_ids"`
 	ID              int64       `json:"id"`
@@ -55,23 +57,23 @@ type Story struct {
 }
 
 type UpdateStory struct {
-	AfterID         int64         `json:"after_id"`
-	Archived        bool          `json:"archived"`
-	BeforeID        int64         `json:"before_id"`
-	Deadline        string        `json:"deadline"`
-	Description     string        `json:"description"`
-	EpicID          int64         `json:"epic_id"`
-	Estimate        int64         `json:"estimate"`
-	FileIds         []int64       `json:"file_ids"`
-	FollowerIds     []string      `json:"follower_ids"`
-	Labels          []CreateLabel `json:"labels"`
-	LinkedFileIds   []int64       `json:"linked_file_ids"`
-	Name            string        `json:"name"`
-	OwnerIds        []string      `json:"owner_ids"`
-	ProjectID       int64         `json:"project_id"`
-	RequestedByID   string        `json:"requested_by_id"`
-	StoryType       string        `json:"story_type"`
-	WorkflowStateID int64         `json:"workflow_state_id"`
+	AfterID         int64         `json:"after_id,omitempty"`
+	Archived        bool          `json:"archived,omitempty"`
+	BeforeID        int64         `json:"before_id,omitempty"`
+	Deadline        string        `json:"deadline,omitempty"`
+	Description     string        `json:"description,omitempty"`
+	EpicID          int64         `json:"epic_id,omitempty"`
+	Estimate        int64         `json:"estimate,omitempty"`
+	FileIds         []int64       `json:"file_ids,omitempty"`
+	FollowerIds     []string      `json:"follower_ids,omitempty"`
+	Labels          []CreateLabel `json:"labels,omitempty"`
+	LinkedFileIds   []int64       `json:"linked_file_ids,omitempty"`
+	Name            string        `json:"name,omitempty"`
+	OwnerIds        []string      `json:"owner_ids,omitempty"`
+	ProjectID       int64         `json:"project_id,omitempty"`
+	RequestedByID   string        `json:"requested_by_id,omitempty"`
+	StoryType       string        `json:"story_type,omitempty"`
+	WorkflowStateID int64         `json:"workflow_state_id,omitempty"`
 }
 
 type SearchStory struct {


### PR DESCRIPTION
This PR contains:
- Adds some missing `omitempty` JSON tags, which was causing `UpdateStory` to overwrite fields with empty values.
- Adds support for Shortcut groups (called teams in the UI).
- Adds the missing `ExternalID` and `GroupID` fields to `CreateStory `.